### PR TITLE
Fix Text::regex

### DIFF
--- a/src/Validator/Text.php
+++ b/src/Validator/Text.php
@@ -124,7 +124,7 @@ class Text extends ValidatorAbstract implements ValidatorInterface
         return $this->pipe(
             self::predicate(
                 function ($value) use ($regex) {
-                    return preg_match($regex, $value) !== false;
+                    return preg_match($regex, $value) === 1;
                 },
                 "does not match $regex"
             )

--- a/test/Validator/Text.php
+++ b/test/Validator/Text.php
@@ -212,10 +212,10 @@ describe(Text::class, function () {
         it('rejects strings that don\'t', function () {
             expect(
                 (new Text)
-                    ->regex('/.+/')
-                    ->validate('')
+                    ->regex('/[a-z]/')
+                    ->validate('123')
                     ->errors()
-            )->toBe([]);
+            )->toBe(['does not match /[a-z]/']);
         });
     });
 


### PR DESCRIPTION
`preg_match` returns `0` when a string doesn't match the regex, not `false` so `Text::regex` would always pass, unless there was an error. It always returns `1` when there's a match so it can just check for that instead.
