### PR TITLE
Hotfix/ints are real

### DIFF
--- a/src/Validator/Real.php
+++ b/src/Validator/Real.php
@@ -14,7 +14,12 @@ class Real extends ValidatorAbstract implements ValidatorInterface
     public function __construct()
     {
         $this->restrictions = [
-            self::strictPredicate('is_numeric', 'not a float')
+            self::strictPredicate(
+                function($real) : bool {
+                    return is_int($real) || is_float($real);
+                },
+                'not a float'
+            )
         ];
     }
 

--- a/src/Validator/Real.php
+++ b/src/Validator/Real.php
@@ -14,7 +14,7 @@ class Real extends ValidatorAbstract implements ValidatorInterface
     public function __construct()
     {
         $this->restrictions = [
-            self::strictPredicate('is_float', 'not a float')
+            self::strictPredicate('is_numeric', 'not a float')
         ];
     }
 

--- a/test/Validator/Real.php
+++ b/test/Validator/Real.php
@@ -14,6 +14,14 @@ describe(Real::class, function () {
             )->toBe([]);
         });
 
+        it('accepts int values', function () {
+            expect(
+                (new Real)
+                    ->validate(2)
+                    ->errors()
+            )->toBe([]);
+        });
+
         it('rejects non-floats', function () {
             expect(
                 (new Real)
@@ -29,6 +37,15 @@ describe(Real::class, function () {
                 (new Real)
                     ->exactly(2)
                     ->validate(2.0)
+                    ->errors()
+            )->toBe([]);
+        });
+
+        it('accepts equal ints', function () {
+            expect(
+                (new Real)
+                    ->exactly(2)
+                    ->validate(2)
                     ->errors()
             )->toBe([]);
         });

--- a/test/Validator/Real.php
+++ b/test/Validator/Real.php
@@ -22,6 +22,22 @@ describe(Real::class, function () {
             )->toBe([]);
         });
 
+        it('accepts infinity', function () {
+            expect(
+                (new Real)
+                    ->validate(INF)
+                    ->errors()
+            )->toBe([]);
+        });
+
+        it('accepts NaN', function () {
+            expect(
+                (new Real)
+                    ->validate(NAN)
+                    ->errors()
+            )->toBe([]);
+        });
+
         it('rejects booleans', function () {
             expect(
                 (new Real)

--- a/test/Validator/Real.php
+++ b/test/Validator/Real.php
@@ -22,10 +22,18 @@ describe(Real::class, function () {
             )->toBe([]);
         });
 
-        it('rejects non-floats', function () {
+        it('rejects booleans', function () {
             expect(
                 (new Real)
                     ->validate(true)
+                    ->errors()
+            )->toBe(['not a float']);
+        });
+
+        it('rejects numeric strings', function () {
+            expect(
+                (new Real)
+                    ->validate('2')
                     ->errors()
             )->toBe(['not a float']);
         });


### PR DESCRIPTION
Fixes bug where `Real` was rejecting integers

This is intended as a bug fix, so the error 'not a float' has _not_ been changed to 'not a real number'. This change should occur in the next major version, but would break bc if errors are parsed.
