### PR TITLE
Format boolean strings

### DIFF
--- a/src/Formatter/Boolean.php
+++ b/src/Formatter/Boolean.php
@@ -14,7 +14,7 @@ class Boolean extends FormatterAbstract implements FormatterInterface
     {
         $this->transformations = [
             function ($value) : bool {
-                return (bool) $value;
+                return 'false' === $value ? false : (bool) $value;
             }
         ];
     }

--- a/test/Formatter/Boolean.php
+++ b/test/Formatter/Boolean.php
@@ -9,6 +9,10 @@ describe(Boolean::class, function () {
         expect((new Boolean)->format(false))->toBe(false);
     });
 
+    it('casts non-boolean values', function () {
+        expect((new Boolean)->format(112358))->toBe(true);
+    });
+
     it('handles the string "true"', function () {
         expect((new Boolean)->format('true'))->toBe(true);
     });
@@ -29,7 +33,15 @@ describe(Boolean::class, function () {
         expect((new Boolean)->format(''))->toBe(false);
     });
 
-    it('casts non-boolean values', function () {
-        expect((new Boolean)->format(112358))->toBe(true);
+    it('doesn\'t over do it', function () {
+        expect((new Boolean)->format('no'))->toBe(true);
+    });
+
+    it('doesn\'t try too hard', function () {
+        expect((new Boolean)->format('off'))->toBe(true);
+    });
+
+    it('doesn\'t speak georgian', function () {
+        expect((new Boolean)->format('ყალბი'))->toBe(true);
     });
 });

--- a/test/Formatter/Boolean.php
+++ b/test/Formatter/Boolean.php
@@ -9,6 +9,26 @@ describe(Boolean::class, function () {
         expect((new Boolean)->format(false))->toBe(false);
     });
 
+    it('handles the string "true"', function () {
+        expect((new Boolean)->format('true'))->toBe(true);
+    });
+
+    it('handles the string "false"', function () {
+        expect((new Boolean)->format('false'))->toBe(false);
+    });
+
+    it('handles the string "1"', function () {
+        expect((new Boolean)->format('1'))->toBe(true);
+    });
+
+    it('handles the string "0"', function () {
+        expect((new Boolean)->format('0'))->toBe(false);
+    });
+
+    it('handles the empty string', function () {
+        expect((new Boolean)->format(''))->toBe(false);
+    });
+
     it('casts non-boolean values', function () {
         expect((new Boolean)->format(112358))->toBe(true);
     });


### PR DESCRIPTION
What's the desired behaviour of `(new Boolean)->format('false')` ? If this library is designed to handle data from incoming http requests, should we format `'false'` to `false` ?
