### PR TITLE
Make validation errors translatable

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -10,16 +10,16 @@
     "packages-dev": [
         {
             "name": "kahlan/kahlan",
-            "version": "3.0.0",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/kahlan/kahlan.git",
-                "reference": "6b932dab1e162cbcdeb5d50c88702ac496127aaf"
+                "reference": "3a48a2e638e31dca1427dd5ae38640b621e8eb3a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/kahlan/kahlan/zipball/6b932dab1e162cbcdeb5d50c88702ac496127aaf",
-                "reference": "6b932dab1e162cbcdeb5d50c88702ac496127aaf",
+                "url": "https://api.github.com/repos/kahlan/kahlan/zipball/3a48a2e638e31dca1427dd5ae38640b621e8eb3a",
+                "reference": "3a48a2e638e31dca1427dd5ae38640b621e8eb3a",
                 "shasum": ""
             },
             "require": {
@@ -61,7 +61,7 @@
                 "testing",
                 "unit test"
             ],
-            "time": "2016-10-03 18:08:08"
+            "time": "2016-10-16 11:23:34"
         }
     ],
     "aliases": [],

--- a/src/Result.php
+++ b/src/Result.php
@@ -60,6 +60,7 @@ class Result
      */
     public function errors() : array
     {
+        // TODO: $this->translate([]);
         return array_map(function (/* ValidationError */ $error) : string {
             return (string) $error;
         }, $this->errors);

--- a/src/Result.php
+++ b/src/Result.php
@@ -80,7 +80,7 @@ class Result
                     return array_merge($carry, [$error->translate($translations[$error->token()])]);
                 }
 
-                return array_merge($carry, (string) $error);
+                return array_merge($carry, [(string) $error]);
             },
             []
         );

--- a/src/Result.php
+++ b/src/Result.php
@@ -68,7 +68,7 @@ class Result
      * @param string $error
      * @return Schemer\Result
      */
-    public static function failure(string $error) : Result
+    public static function failure(/* ValidationError */ $error) : Result
     {
         return new self([$error]);
     }

--- a/src/Result.php
+++ b/src/Result.php
@@ -60,7 +60,25 @@ class Result
      */
     public function errors() : array
     {
-        return $this->errors;
+        return array_map(function ($error) {
+            return (string) $error;
+        }, $this->errors);
+    }
+
+    /**
+     * Get and translate the errors for this result.
+     * @param array $translations
+     * @return array
+     */
+    public function translate(array $translations) : array
+    {
+        return array_reduce($this->errors, function (array $carry, ValidationError $error) use ($translations) {
+            if (array_key_exists($error->token(), $translations)) {
+                return array_merge($carry, [$error->translate($translations[$error->token()])]);
+            }
+
+            return array_merge($carry, (string) $error);
+        }, []);
     }
 
     /**

--- a/src/Result.php
+++ b/src/Result.php
@@ -60,7 +60,7 @@ class Result
      */
     public function errors() : array
     {
-        return array_map(function ($error) {
+        return array_map(function (/* ValidationError */ $error) : string {
             return (string) $error;
         }, $this->errors);
     }
@@ -72,13 +72,17 @@ class Result
      */
     public function translate(array $translations) : array
     {
-        return array_reduce($this->errors, function (array $carry, ValidationError $error) use ($translations) {
-            if (array_key_exists($error->token(), $translations)) {
-                return array_merge($carry, [$error->translate($translations[$error->token()])]);
-            }
+        return array_reduce(
+            $this->errors,
+            function (array $carry, ValidationError $error) use ($translations) : array {
+                if (array_key_exists($error->token(), $translations)) {
+                    return array_merge($carry, [$error->translate($translations[$error->token()])]);
+                }
 
-            return array_merge($carry, (string) $error);
-        }, []);
+                return array_merge($carry, (string) $error);
+            },
+            []
+        );
     }
 
     /**

--- a/src/ValidationError.php
+++ b/src/ValidationError.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Schemer;
+
+class ValidationError
+{
+    private /* const */ $messages = [
+        'NOT_ALPHANUMERIC' => 'not alphanumeric',
+        'NOT_EMAIL' => 'not an email',
+        'LENGTH_MISMATCH' => 'not exactly %d %s',
+        'NOT_LOWERCASE' => 'not all lowercase',
+        'NOT_UPPERCASE' => 'not all uppercase',
+        'TOO_LONG' => 'more than %d %s',
+        'TOO_SHORT' => 'less than %d %s',
+        'REGEX_MISMATCH' => 'does not match %s',
+    ];
+
+    public function __construct(string $token, array $values /* this name is bad */ = [])
+    {
+        $this->message = $this->messages[$token];
+        $this->values = $values;
+    }
+
+    public function translate(string $message)
+    {
+        return sprintf($message, ...$this->values);
+    }
+
+    public function __toString()
+    {
+        return sprintf($this->message, ...$this->values);
+    }
+}

--- a/src/ValidationError.php
+++ b/src/ValidationError.php
@@ -31,12 +31,12 @@ final class ValidationError
         $this->values = $values;
     }
 
-    public function token()
+    public function token() : string
     {
         return $this->token;
     }
 
-    public function translate(string $message)
+    public function translate(string $message) : string
     {
         // prefer a custom message over this translation
         if ($this->message !== $this->messages[$this->token]) {
@@ -46,7 +46,7 @@ final class ValidationError
         return sprintf($message, ...$this->values);
     }
 
-    public function __toString()
+    public function __toString() : string
     {
         return sprintf($this->message, ...$this->values);
     }

--- a/src/ValidationError.php
+++ b/src/ValidationError.php
@@ -17,8 +17,14 @@ class ValidationError
 
     public function __construct(string $token, array $values /* this name is bad */ = [])
     {
+        $this->token = $token;
         $this->message = $this->messages[$token];
         $this->values = $values;
+    }
+
+    public function token()
+    {
+        return $this->token;
     }
 
     public function translate(string $message)

--- a/src/ValidationError.php
+++ b/src/ValidationError.php
@@ -2,23 +2,32 @@
 
 namespace Schemer;
 
-class ValidationError
+final class ValidationError
 {
+    const NOT_ALPHANUMERIC = 'NOT_ALPHANUMERIC';
+    const NOT_EMAIL = 'NOT_EMAIL';
+    const LENGTH_MISMATCH = 'LENGTH_MISMATCH';
+    const NOT_LOWERCASE = 'NOT_LOWERCASE';
+    const NOT_UPPERCASE = 'NOT_UPPERCASE';
+    const TOO_LONG = 'TOO_LONG';
+    const TOO_SHORT = 'TOO_SHORT';
+    const REGEX_MISMATCH = 'REGEX_MISMATCH';
+
     private /* const */ $messages = [
-        'NOT_ALPHANUMERIC' => 'not alphanumeric',
-        'NOT_EMAIL' => 'not an email',
-        'LENGTH_MISMATCH' => 'not exactly %d %s',
-        'NOT_LOWERCASE' => 'not all lowercase',
-        'NOT_UPPERCASE' => 'not all uppercase',
-        'TOO_LONG' => 'more than %d %s',
-        'TOO_SHORT' => 'less than %d %s',
-        'REGEX_MISMATCH' => 'does not match %s',
+        self::NOT_ALPHANUMERIC => 'not alphanumeric',
+        self::NOT_EMAIL => 'not an email',
+        self::LENGTH_MISMATCH => 'not exactly %d %s',
+        self::NOT_LOWERCASE => 'not all lowercase',
+        self::NOT_UPPERCASE => 'not all uppercase',
+        self::TOO_LONG => 'more than %d %s',
+        self::TOO_SHORT => 'less than %d %s',
+        self::REGEX_MISMATCH => 'does not match %s',
     ];
 
-    public function __construct(string $token, array $values /* this name is bad */ = [])
+    public function __construct(string $token, string $message = '', array $values /* this name is bad */ = [])
     {
         $this->token = $token;
-        $this->message = $this->messages[$token];
+        $this->message = $message ?: $this->messages[$token];
         $this->values = $values;
     }
 
@@ -29,6 +38,11 @@ class ValidationError
 
     public function translate(string $message)
     {
+        // prefer a custom message over this translation
+        if ($this->message !== $this->messages[$this->token]) {
+            return (string) $this;
+        }
+
         return sprintf($message, ...$this->values);
     }
 

--- a/src/Validator/Text.php
+++ b/src/Validator/Text.php
@@ -3,6 +3,7 @@
 namespace Schemer\Validator;
 
 use Schemer\Result;
+use Schemer\ValidationError;
 
 /**
  * Text validator.
@@ -49,7 +50,7 @@ class Text extends ValidatorAbstract
                 function (string $value) : bool {
                     return filter_var($value, FILTER_VALIDATE_EMAIL) !== false;
                 },
-                'not an email'
+                new ValidationError('NOT_EMAIL')
             )
         );
     }

--- a/src/Validator/Text.php
+++ b/src/Validator/Text.php
@@ -43,14 +43,14 @@ class Text extends ValidatorAbstract
      * This string must be an email.
      * @return Schemer\Validator\Text
      */
-    public function email() : Text
+    public function email(string $error = '') : Text
     {
         return $this->pipe(
             self::predicate(
                 function (string $value) : bool {
                     return filter_var($value, FILTER_VALIDATE_EMAIL) !== false;
                 },
-                new ValidationError('NOT_EMAIL')
+                new ValidationError(ValidationError::NOT_EMAIL, $error)
             )
         );
     }

--- a/src/Validator/ValidatorAbstract.php
+++ b/src/Validator/ValidatorAbstract.php
@@ -36,7 +36,7 @@ class ValidatorAbstract implements ValidatorInterface
      */
     protected static function predicate(
         callable $predicate,
-        string $error
+        /* ValidationError */ $error
     ) : callable {
         return function ($value) use ($predicate, $error) : Result {
             return $predicate($value)

--- a/test/Validator/Text.php
+++ b/test/Validator/Text.php
@@ -78,8 +78,19 @@ describe(Text::class, function () {
                 (new Text)
                     ->email()
                     ->validate('test.com')
-                    ->errors()
-            )->toBe(['not an email']);
+                    ->errors()[0]
+                    ->__toString()
+            )->toBe('not an email');
+        });
+
+        it('can be translated', function () {
+            expect(
+                (new Text)
+                    ->email()
+                    ->validate('test.com')
+                    ->errors()[0]
+                    ->translate('hello')
+            )->toBe('hello');
         });
     });
 

--- a/test/Validator/Text.php
+++ b/test/Validator/Text.php
@@ -90,6 +90,24 @@ describe(Text::class, function () {
                     ->translate(['NOT_EMAIL' => 'hello'])
             )->toBe(['hello']);
         });
+
+        it('can accept a custom message', function () {
+            expect(
+                (new Text)
+                    ->email('hi')
+                    ->validate('test.com')
+                    ->errors()
+            )->toBe(['hi']);
+        });
+
+        it('prefers the message over a translation', function () {
+            expect(
+                (new Text)
+                    ->email('cool and good')
+                    ->validate('test.com')
+                    ->translate(['NOT_EMAIL' => 'wrong and bad'])
+            )->toBe(['cool and good']);
+        });
     });
 
     context('->length', function () {

--- a/test/Validator/Text.php
+++ b/test/Validator/Text.php
@@ -78,9 +78,8 @@ describe(Text::class, function () {
                 (new Text)
                     ->email()
                     ->validate('test.com')
-                    ->errors()[0]
-                    ->__toString()
-            )->toBe('not an email');
+                    ->errors()
+            )->toBe(['not an email']);
         });
 
         it('can be translated', function () {
@@ -88,9 +87,8 @@ describe(Text::class, function () {
                 (new Text)
                     ->email()
                     ->validate('test.com')
-                    ->errors()[0]
-                    ->translate('hello')
-            )->toBe('hello');
+                    ->translate(['NOT_EMAIL' => 'hello'])
+            )->toBe(['hello']);
         });
     });
 


### PR DESCRIPTION
I'm not sure how much I like this interface so can you take a look? There's still some work to make this not a bc break and to allow overwriting all error messages of the same type.
